### PR TITLE
fix(): update ionic schematics name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Angular schematics extension for Visual Studio Code
 
 [Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=cyrilletuzi.angular-schematics)
-allowing you to launch Angular schematics (CLI commands) 
+allowing you to launch Angular schematics (CLI commands)
 with a Graphical User Interface, directly inside VS Code!
 
 ## Why?
@@ -79,7 +79,7 @@ it must be configured accordingly in your VS Code settings
 By default, this extension supports (if they are installed):
 - `@schematics/angular` (official Angular CLI commands)
 - `@angular/material`
-- `@ionic/angular-schematics`
+- `@ionic/angular-toolkit`
 - `@ngrx/schematics`
 - `@nrwl/schematics`
 - `@nstudio/schematics`

--- a/src/schematics/schematics.ts
+++ b/src/schematics/schematics.ts
@@ -22,7 +22,7 @@ export class Schematics {
     static defaultCollection = '';
     static commonCollections: string[] = [
         '@angular/material',
-        '@ionic/schematics-angular',
+        '@ionic/angular-toolkit',
         '@ngrx/schematics',
         '@nrwl/schematics',
         '@nstudio/schematics',

--- a/src/schematics/view.ts
+++ b/src/schematics/view.ts
@@ -30,7 +30,7 @@ export class AngularSchematicsProvider implements vscode.TreeDataProvider<vscode
         ['@ngrx/schematics:entity', 'ngrx-entity.svg'],
         ['@ngrx/schematics:reducer', 'ngrx-reducer.svg'],
         ['@ngrx/schematics', 'ngrx-state.svg'],
-        ['@ionic/schematics-angular', 'ionic.svg'],
+        ['@ionic/angular-toolkit', 'ionic.svg'],
     ]);
     private materialIconsExisting = new Set<string>();
     private materialIconsNotExisting = new Set<string>();
@@ -68,7 +68,7 @@ export class AngularSchematicsProvider implements vscode.TreeDataProvider<vscode
     }
 
     async getChildren(element?: vscode.TreeItem | undefined): Promise<vscode.TreeItem[]> {
-        
+
         if (this.workspaceRoot) {
 
             if (!element) {
@@ -96,7 +96,7 @@ export class AngularSchematicsProvider implements vscode.TreeDataProvider<vscode
                     }
 
                     return items;
-                    
+
                 }
 
             }
@@ -138,7 +138,7 @@ export class AngularSchematicsProvider implements vscode.TreeDataProvider<vscode
             }
 
         }
-        
+
         return vscode.Uri.file(iconPath);
 
     }


### PR DESCRIPTION
Hi there! I'm from the ionic team and noticed that the schematics you point to is our older one. This PR updates it to the new package name. Cheers!