### PR TITLE
feat: new schematics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [1.19.0] - 2019-03-01
+
+### Feature
+
+- Default support for these schematics:
+  - `@ngxs/schematics`
+  - `@nativescript/schematics`
+  - `@ngx-formly/schematics`
+  - `primeng-schematics`
+  - `@ngx-kit/collection`
+  - `ngx-spec`
+
 ## [1.18.0] - 2019-02-23
 
 ### Feature

--- a/src/schematics/schematics.ts
+++ b/src/schematics/schematics.ts
@@ -14,8 +14,14 @@ export class Schematics {
         '@angular/material',
         '@ionic/angular-toolkit',
         '@ngrx/schematics',
+        '@ngxs/schematics',
+        '@nativescript/schematics',
         '@nrwl/schematics',
         '@nstudio/schematics',
+        '@ngx-formly/schematics',
+        'primeng-schematics',
+        '@ngx-kit/collection',
+        'ngx-spec',
         './schematics/collection.json'
     ];
     static collections: Set<string> = new Set();


### PR DESCRIPTION
Default support for these schematics:
- `@ngxs/schematics`
- `@nativescript/schematics`
- `@ngx-formly/schematics`
- `primeng-schematics`
- `@ngx-kit/collection`
- `ngx-spec`

Fixes #30 