### PR TITLE
feat: disable useless entry component type when in Ivy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.2.0] - 2019-11-03
+
+### Feature
+
+- Disable entry component type when in Ivy, as `--entry-component` option is not required anymore
+
 ## [2.1.0] - 2019-10-22
 
 ### New powerful and customizable component types management

--- a/README.md
+++ b/README.md
@@ -106,12 +106,17 @@ Thus, they should not be called via a HTML tag and so should not have a selector
 
 #### Entry component
 
-Most of the time, Angular automatically manage the internal code to instantiate components,
+This behavior is *not* required anymore with [Ivy](https://angular.io/guide/ivy)
+(ie. Angular >= 9 with default config or Angular 8 with Ivy explicitly enable).
+It's only *required in non-Ivy mode*
+(ie. Angular <= 7, Angular 8 with default config or Angular 9 with Ivy explicitly disabled).
+
+Most of the time, Angular automatically manages the internal code to instantiate components,
 because they are either associated to a route (ie. pages) or used somewhere in a template (ie. presentation components).
 
 But dialogs (like in Angular Material), modals (like in Ionic)
 and [Angular Elements](https://angular.io/guide/elements)
-are invoked at runtime, so it's required to register them in `entryComponents`.
+are invoked at runtime, so it was required to register them in `entryComponents`.
 
 #### Component with Shadow DOM encapsulation
 
@@ -133,11 +138,11 @@ ie. distinguishing components behaviors (explained above), or for tools with spe
 By default, the extension will propose you these component types:
 
 - Component: no special behavior
-- Page: component associated to a route (`--skip-selector`)
+- Page: component associated to a route (`--skip-selector`) & modals/dialogs (Angular >=9)
 - Pure: presentation / UI component (`--change-detection OnPush`)
-- Runtime: component like modals or dialogs (`--skip-selector --entry-component`)
 - Exported: pure component reused outside of their modules, ie. component lib (`--exported --change-detection OnPush`)
 - Element: Angular Element, ie. a native Web Component (`--entry-component --view-encapsulation ShadowDom`)
+- Runtime: component like modals or dialogs (`--skip-selector --entry-component`) (Angular <=8)
 
 #### Customize component suffixes (Angular >= 9)
 
@@ -161,9 +166,9 @@ not for the default component types, as otherwise lint would fail.
 Some common suffixes will automatically pre-select the recommended behaviors:
 - `Pure`, `UI`, `Presentation`, `Presentational`, `Dumb` > `--change-detection OnPush`
 - `Page`, `Container`, `Smart`, `Routed`, `Route` > `--skip-selector`
-- `Dialog`, `SnackBar`, `BottomSheet`, `Modal`, `Popover`, `Entry` > `--skip-selector --entry-component`
 - `Exported`, `Lib` > `--exported --change-detection OnPush`
-- `Element` > `--entry-component --view-encapsulation ShadowDom`: 
+- `Element` > `--entry-component --view-encapsulation ShadowDom`
+- `Dialog`, `SnackBar`, `BottomSheet`, `Modal`, `Popover`, `Entry` > `--skip-selector` (Angular >=9) or `--skip-selector --entry-component` (Angular <=8)
 
 The list above includes common suffixes in Angular, Material and Ionic.
 If you think some other common suffixes are missing, please open a Pull Request with new
@@ -172,9 +177,9 @@ If you think some other common suffixes are missing, please open a Pull Request 
 For uncommon suffixes, you can add a custom configuration in VS Code preferences:
 - pure: `"ngschematics.componentTypes.pure": ["Custom"]`
 - no selector: `"ngschematics.componentTypes.page": ["Custom"]`
-- no selector & entry: `"ngschematics.componentTypes.runtime": ["Custom"]`
 - exported & pure: `"ngschematics.componentTypes.exported": ["Custom"]`
 - entry & shadow: `"ngschematics.componentTypes.element": ["Custom"]`
+- no selector & entry: `"ngschematics.componentTypes.runtime": ["Custom"]` (Angular <=8 only)
 
 #### Default suffix
 

--- a/src/schematics/commands.ts
+++ b/src/schematics/commands.ts
@@ -240,7 +240,7 @@ export class Commands {
         const elementComponentTypes: string[] = Preferences.getComponentTypes('element');
 
         const noSelectorComponentTypes: string[] = [...pageComponentTypes, ...runtimeComponentTypes];
-        const entryComponentTypes: string[] = [...elementComponentTypes, ...runtimeComponentTypes];
+        const entryComponentTypes: string[] = AngularConfig.isIvy ? [] : [...elementComponentTypes, ...runtimeComponentTypes];
         const allPureComponentTypes: string[] = [...pureComponentTypes, ...exportedComponentTypes];
 
         const componentOptions = new Map<string, string | string[]>();
@@ -257,7 +257,7 @@ export class Commands {
             if (pureComponentTypes.includes(componentSuffixLowerCase)) {
                 description = `Pure presentation / UI component`;
             } else if (pageComponentTypes.includes(componentSuffixLowerCase)) {
-                description = `Component associated to a route`;
+                description = `Component associated to a route${AngularConfig.isIvy ? ' or modals/dialogs' : ''}`;
             } else if (runtimeComponentTypes.includes(componentSuffixLowerCase)) {
                 description = `Runtime component, like dialogs or modals`;
             } else if (exportedComponentTypes.includes(componentSuffixLowerCase)) {
@@ -318,7 +318,7 @@ export class Commands {
         });
 
         const entryComponentOption = schema.options.get('entryComponent');
-        if (entryComponentOption) {
+        if (!AngularConfig.isIvy && entryComponentOption) {
             componentBehaviors.push({
                 label: TYPE_ENTRY,
                 description: `--entry-component`,

--- a/src/schematics/tslint-config.ts
+++ b/src/schematics/tslint-config.ts
@@ -1,7 +1,9 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
+
 import { Utils } from './utils';
 import { Preferences } from './preferences';
+import { AngularConfig } from './angular-config';
 
 export interface TSLintConfigSchema {
     rules?: {
@@ -63,7 +65,7 @@ export class TSLintConfig {
                 if (!hasPureType) {
                     componentSuffixesSet.add('Pure');
                 }
-                if (!hasRuntimeType) {
+                if (!AngularConfig.isIvy && !hasRuntimeType) {
                     componentSuffixesSet.add('Entry');
                 }
                 if (!hasExportedType) {

--- a/src/schematics/utils.ts
+++ b/src/schematics/utils.ts
@@ -86,8 +86,6 @@ export class Utils {
 
     static async parseJSONFile<T = unknown>(path: string): Promise<T | null> {
 
-        console.log(path);
-
         let json: T | null = null;
     
         try {


### PR DESCRIPTION
`entryComponents` is not useful anymore and [deprecated in Angular 9](https://next.angular.io/guide/deprecations#entryComponents).