### PR TITLE
feat: disable compactFolders setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [3.2.0] - 2020-02-15
+
+### VS Code compact folders
+
+Since [VS Code 1.41](https://code.visualstudio.com/updates/v1_41#_compact-folders-in-explorer),
+a new default behavior combines single folders together.
+
+While it might be a good idea in general, it is annoying with this extension,
+as clicking on the right directory where you want to generate something becomes more confusing.
+
+So the extension will disable this setting for you in `.vscode/settings.json`
+(only in Angular projects).
+
+If you want to keep the default VS Code behavior, just revert it:
+`"explorer.compactFolders": true`
+
 ## [3.1.0] - 2020-02-15
 
 ### UX improvements

--- a/README.md
+++ b/README.md
@@ -224,10 +224,26 @@ this extension can load them too. By default, the extension will look into `./sc
 
 If your schematics collection path is different,
 you can add:
-- a *relative* path in VS Code preferences: `"ngschematics.schematics": ["./path/to/collection.json"]`
-- if it's a package in `node_modules`: `"ngschematics.schematics": ["my-private-lib"]`
+- a *relative* path in VS Code preferences:
+`"ngschematics.schematics": ["./path/to/collection.json"]`
+- if it's a package in `node_modules`:
+`"ngschematics.schematics": ["my-private-lib"]`
 
 ## Other features
+
+### VS Code compact folders
+
+Since [VS Code 1.41](https://code.visualstudio.com/updates/v1_41#_compact-folders-in-explorer),
+a new default behavior combines single folders together.
+
+While it might be a good idea in general, it is annoying with this extension,
+as clicking on the right directory where you want to generate something becomes more confusing.
+
+So the extension will disable this setting for you in `.vscode/settings.json`
+(only in Angular projects).
+
+If you want to keep the default VS Code behavior, just revert it:
+`"explorer.compactFolders": true`
 
 ### Keyboard shortcuts
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { Commands } from './schematics/commands';
 import { GenerateConfig } from './schematics/commands';
 import { Output } from './schematics/output';
 import { AngularConfig } from './schematics/angular-config';
+import { Preferences } from './schematics/preferences';
 
 
 // this method is called when your extension is activated
@@ -14,6 +15,8 @@ import { AngularConfig } from './schematics/angular-config';
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 
     vscode.commands.executeCommand('setContext', 'inAngularProject', true);
+
+    Preferences.disableCompactFolders();
 
     vscode.window.registerTreeDataProvider('angular-schematics', new AngularSchematicsProvider());
 

--- a/src/schematics/preferences.ts
+++ b/src/schematics/preferences.ts
@@ -65,11 +65,11 @@ export class Preferences {
 
     static disableCompactFolders(): void {
 
-
         const settingName = 'explorer.compactFolders';
 
         const setting = vscode.workspace.getConfiguration().inspect(settingName);
 
+        /* Do not override user settings */
         if (setting && (setting.globalValue === undefined) && (setting.workspaceValue === undefined)) {
 
             vscode.workspace.getConfiguration().update(settingName, false, vscode.ConfigurationTarget.Workspace)

--- a/src/schematics/preferences.ts
+++ b/src/schematics/preferences.ts
@@ -63,4 +63,20 @@ export class Preferences {
 
     }
 
+    static disableCompactFolders(): void {
+
+
+        const settingName = 'explorer.compactFolders';
+
+        const setting = vscode.workspace.getConfiguration().inspect(settingName);
+
+        if (setting && (setting.globalValue === undefined) && (setting.workspaceValue === undefined)) {
+
+            vscode.workspace.getConfiguration().update(settingName, false, vscode.ConfigurationTarget.Workspace)
+            .then(() => {}, () => {});
+
+        }
+
+    }
+
 }


### PR DESCRIPTION
Since [VS Code 1.41](https://code.visualstudio.com/updates/v1_41#_compact-folders-in-explorer), a new default behavior combines single folders together.

While it might be a good idea in general, it is annoying with this extension, as clicking on the right directory where you want to generate something becomes more confusing.

So the extension will disable this setting for you in `.vscode/settings.json` (only in Angular projects).

If you want to keep the default VS Code behavior, just revert it:
`"explorer.compactFolders": true`