### PR TITLE
Shortchuts use Angular CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Change Log
 
+## [3.3.0] - 2020-02-20
+
+### Shortchuts use Angular CLI
+
+Generation shortcuts ("Generate a component/service/module") are based on official Angular CLI schematics.
+But before v3.3 of this extension,
+the final command was launched with the default schematics configured in your `angular.json`.
+
+This was problematic for Ionic users, were a custom version of Angular schematics
+is set as default (`@ionic/angular-toolkit`). Unfortunately, these schematics are completely outdated
+(some important options like `--change-detection` or `--skip-selector` are missing),
+and some are even buggy (lazy-loaded module schematics is failing).
+
+Now Angular CLI is always used in shortcuts,
+so you can take advantage of up to date official schematics.
+You can still use custom schematics with "Generate another schematics".
+
+While Ionic custom schematics were useful in Ionic 3,
+because Ionic added special things on top of Angular,
+they are now useless in Ionic >= 4, which is just standard Angular.
+So you should remove the following line of config in your `angular.json`,
+to take advantage of the official and up to date Angular CLI schematics instead:
+
+```json
+{ "cli": { "defaultCollection": "@ionic/angular-toolkit" } }
+```
+
 ## [3.2.1] - 2020-02-19
 
 ### VS Code compact folders

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ On macOS or Linux, if you use a custom shell (like `zsh`) and your Angular CLI i
 it must be configured accordingly in your VS Code settings
 (`terminal.integrated.shell.osx` or `terminal.integrated.shell.linux`).
 
-## Recommendation
+## Recommendations
 
 ### VS Code compact folders
 
@@ -97,6 +97,23 @@ as clicking on the right directory where you want to generate something becomes 
 
 So you should consider disabling this setting in your VS Code *workspace* preferences:
 `"explorer.compactFolders": false`
+
+### Ionic
+
+Ionic configures custom default schematics in `angular.json`:
+```json
+{ "cli": { "defaultCollection": "@ionic/angular-toolkit" } }
+```
+
+Unfortunately, these schematics are completely outdated
+(some important options like `--change-detection` or `--skip-selector` are missing),
+and some are even buggy (lazy-loaded module schematics is failing).
+
+While Ionic custom schematics were useful in Ionic 3,
+because Ionic added special things on top of Angular,
+they are now useless in Ionic >= 4, which is just standard Angular.
+So you should remove this line of config in your `angular.json`,
+to take advantage of the official and up to date Angular CLI schematics instead.
 
 ## Component good practices
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,11 +2,14 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+
 import { AngularSchematicsProvider } from './schematics/view';
 import { Commands } from './schematics/commands';
 import { GenerateConfig } from './schematics/commands';
 import { Output } from './schematics/output';
 import { AngularConfig } from './schematics/angular-config';
+import { Preferences } from './schematics/preferences';
+import { ExplorerMenuContext } from './schematics/workspace';
 
 
 // this method is called when your extension is activated
@@ -17,10 +20,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     vscode.window.registerTreeDataProvider('angular-schematics', new AngularSchematicsProvider());
 
+    Preferences.init();
+
     // The command has been defined in the package.json file
     // Now provide the implementation of the command with  registerCommand
     // The commandId parameter must match the command field in package.json
-    const generateComponentCommand = vscode.commands.registerCommand('ngschematics.generateComponent', async (context) => {
+    const generateComponentCommand = vscode.commands.registerCommand('ngschematics.generateComponent', async (context: ExplorerMenuContext) => {
 
         await Commands.generate(context, {
             collectionName: AngularConfig.cliCollection,
@@ -29,7 +34,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     });
 
-    const generateServiceCommand = vscode.commands.registerCommand('ngschematics.generateService', async (context) => {
+    const generateServiceCommand = vscode.commands.registerCommand('ngschematics.generateService', async (context: ExplorerMenuContext) => {
 
         await Commands.generate(context, {
             collectionName: AngularConfig.cliCollection,
@@ -38,7 +43,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     });
 
-    const generateModuleCommand = vscode.commands.registerCommand('ngschematics.generateModule', async (context) => {
+    const generateModuleCommand = vscode.commands.registerCommand('ngschematics.generateModule', async (context: ExplorerMenuContext) => {
 
         await Commands.generate(context, {
             collectionName: AngularConfig.cliCollection,
@@ -47,7 +52,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     });
 
-    const generateCommand = vscode.commands.registerCommand('ngschematics.generate', async (context, options: GenerateConfig = {}) => {
+    const generateCommand = vscode.commands.registerCommand('ngschematics.generate', async (context: ExplorerMenuContext, options: GenerateConfig = {}) => {
 
         await Commands.generate(context, options);
 

--- a/src/schematics/generate.ts
+++ b/src/schematics/generate.ts
@@ -200,7 +200,7 @@ export class Generate {
 
     protected formatCollectionAndSchema(): string {
 
-        return (this.collection !== AngularConfig.cliCollection) ?
+        return (this.collection !== AngularConfig.defaultCollection) ?
             `${this.collection}:${this.schema}` :
             this.schema;
 

--- a/src/schematics/workspace.ts
+++ b/src/schematics/workspace.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+
+export interface ExplorerMenuContext {
+    path: string;
+}
+
+export class Workspace {
+
+    static getContextPath(context?: ExplorerMenuContext): string {
+
+        /* Check if there is an Explorer context (command could be launched from Palette too, where there is no context) */
+        return (typeof context === 'object') && (context !== null) && ('path' in context) ? context.path : '';
+
+    }
+
+    static getDefaultWorkspace(): vscode.WorkspaceFolder | null {
+
+        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length === 1) {
+            return vscode.workspace.workspaceFolders[0];
+        }
+
+        return null;
+
+    }
+
+    static async getWorkspaceFolderPath(path = ''): Promise<string> {
+
+        const workspaceFolder = path ?
+            vscode.workspace.getWorkspaceFolder(vscode.Uri.file(path)) :
+            (this.getDefaultWorkspace() || await vscode.window.showWorkspaceFolderPick());
+
+        return workspaceFolder ? workspaceFolder.uri.fsPath : '';
+
+    }
+
+} 


### PR DESCRIPTION
Generation shortcuts ("Generate a component/service/module") are based on official Angular CLI schematics. But before v3.3 of this extension, the final command was launched with the default schematics configured in your `angular.json`.

This was problematic for Ionic users, were a custom version of Angular schematics is set as default (`@ionic/angular-toolkit`). Unfortunately, these schematics are completely outdate (some important options like `--change-detection` or `--skip-selector` are missing), and some are even buggy (lazy-loaded module schematics is failing).

Now Angular CLI is always used in shortcuts, so you can take advantage of up to date official schematics. You can still use custom schematics with "Generate another schematics".

While Ionic custom schematics were useful in Ionic 3, because Ionic added special things on top of Angular, they are now useless in Ionic >= 4, which is just standard Angular. So you should remove the following line of config in your `angular.json`, to take advantage of the official and up to date Angular CLI schematics instead:

```json
{ "cli": { "defaultCollection": "@ionic/angular-toolkit" } }
```