### PR TITLE
fix: add @angular/cdk in defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [4.0.2] - 2020-04-15
+
+### Fix
+
+Angular Material has additional schematics in `@angular/cdk` package,
+so it has been added in the defaults detected schematics.
+
 ## [4.0.1] - 2020-04-14
 
 ### Fix

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -3,6 +3,7 @@
  */
 export const defaultCollectionsNames: string[] = [
     '@angular/material',
+    '@angular/cdk',
     '@ionic/angular-toolkit',
     '@ngrx/schematics',
     '@ngxs/schematics',

--- a/src/generation/cli-command.ts
+++ b/src/generation/cli-command.ts
@@ -262,7 +262,7 @@ export class CliCommand {
 
             }
             /* All Material schematics have a component suffix */
-            else if (this.collectionName === '@angular/material') {
+            else if (['@angular/material', '@angular/cdk'].includes(this.collectionName)) {
                 suffix = '.component';
             }
             else if (this.collectionName === '@ngrx/schematics') {


### PR DESCRIPTION
Angular Material has additional schematics in `@angular/cdk` package, so it has been added in the defaults detected packages.