### PR TITLE
fix: add a nowhere choice when prompting where to import a module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [4.0.3] - 2020-04-16
+
+### Fix
+
+Some modules may not be imported immediately,
+so add a "Nowhere" choice when asking where to import a module of components.
+
 ## [4.0.2] - 2020-04-15
 
 ### Fix

--- a/src/generation/user-journey.ts
+++ b/src/generation/user-journey.ts
@@ -423,6 +423,8 @@ export class UserJourney {
 
     private async askWhereToImportModule(): Promise<string | undefined> {
 
+        const nowhereLabel = `Nowhere`;
+
         /* Should look only in the current project */
         const pattern = new vscode.RelativePattern(this.cliCommand.getProjectSourcePath(), '**/*.module.ts');
 
@@ -441,10 +443,16 @@ export class UserJourney {
             return undefined;
         }
 
+        modulesChoices.unshift(nowhereLabel);
+
         const whereToImportChoice = await vscode.window.showQuickPick(modulesChoices, {
             placeHolder: `Where do you want to import the module?`,
             ignoreFocusOut: true,
         });
+
+        if (whereToImportChoice === nowhereLabel) {
+            return undefined;
+        }
 
         return whereToImportChoice?.replace('.module.ts', '');
 


### PR DESCRIPTION
Some modules may not be imported immediately, so add a "Nowhere" choice when asking where to import a module of components.

Fixes #132 