### PR TITLE
Fix/moduleimportpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [4.0.4] - 2020-05-04
+
+### Fix
+
+When choosing where to import a module of components,
+module choice must contain its path (not just its name)
+when the target module is not in a parent folder of the new module.
+
 ## [4.0.3] - 2020-04-16
 
 ### Fix

--- a/src/generation/user-journey.ts
+++ b/src/generation/user-journey.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 
 import { angularCollectionName, extensionName } from '../defaults';
 import { Output, FileSystem, Terminal } from '../utils';

--- a/src/generation/user-journey.ts
+++ b/src/generation/user-journey.ts
@@ -437,7 +437,8 @@ export class UserJourney {
         const modulesChoices = existingModulesUris
             /* Routing module should not be proposed */
             .filter((uri) => !uri.fsPath.includes('-routing'))
-            .map((uri) => path.basename(uri.fsPath));
+            /* We keep only the relative module path, and stop at `-10` to remove `.module.ts` */
+            .map((uri) => uri.fsPath.substring(this.cliCommand.getProjectSourcePath().length + 1, uri.fsPath.length - 10));
 
         if (modulesChoices.length === 0) {
             return undefined;
@@ -450,11 +451,7 @@ export class UserJourney {
             ignoreFocusOut: true,
         });
 
-        if (whereToImportChoice === nowhereLabel) {
-            return undefined;
-        }
-
-        return whereToImportChoice?.replace('.module.ts', '');
+        return whereToImportChoice;
 
     }
 


### PR DESCRIPTION
When choosing where to import a module of components, module choice must contain its path (not just its name) when the target module is not in a parent folder of the new module.