### PR TITLE
fix: nowhere choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [4.0.5] - 2020-05-08
+
+### Fix
+
+Fixes an issue introduced in 4.0.4 where the "Nowhere" choice when generating a module
+of components was not working anymore.
+
 ## [4.0.4] - 2020-05-04
 
 ### Fix

--- a/src/generation/user-journey.ts
+++ b/src/generation/user-journey.ts
@@ -450,7 +450,7 @@ export class UserJourney {
             ignoreFocusOut: true,
         });
 
-        return whereToImportChoice;
+        return (whereToImportChoice !== nowhereLabel) ? whereToImportChoice : undefined;
 
     }
 


### PR DESCRIPTION
Fixes #151 

Fixes an issue introduced in 4.0.4 where the "Nowhere" choice when generating a module
of components was not working anymore.