### PR TITLE
feat: add dryrun choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [4.3.0] - 2020-06-12
+
+### Feature
+
+When adding options, add a new choice on final confirmation to test the command with `--dryRun`.
+
 ## [4.2.0] - 2020-06-12
 
 ### Feature

--- a/src/generation/cli-command.ts
+++ b/src/generation/cli-command.ts
@@ -219,11 +219,13 @@ export class CliCommand {
     /**
      * Launch command in a terminal
      */
-    launchCommand(): void {
+    launchCommand({ dryRun = false } = {}): void {
 
         Output.logInfo(`Launching this command: ${this.getCommand()}`);
 
-        Terminal.send(this.workspaceFolder, this.getCommand());
+        const command = `${this.getCommand()}${dryRun ? ` --dryRun` : ''}`;
+
+        Terminal.send(this.workspaceFolder, command);
     
     }
 

--- a/src/generation/user-journey.ts
+++ b/src/generation/user-journey.ts
@@ -586,10 +586,14 @@ export class UserJourney {
     private async askConfirmation(): Promise<boolean> {
 
         const confirmationLabel = `$(check) Confirm`;
+        const testLabel = `$(debug-alt) Test`;
 
         const confirmationChoices: vscode.QuickPickItem[] = [{
             label: confirmationLabel,
             description: `Pro-tip: take a minute to check the command above is really what you want`,
+        }, {
+            label: testLabel,
+            description: `Simulate the command with --dryRun`,
         }, {
             label: `$(close) Cancel`,
         }];
@@ -598,6 +602,14 @@ export class UserJourney {
             placeHolder: this.cliCommand.getCommand(),
             ignoreFocusOut: true,
         });
+
+        if (choice?.label === testLabel) {
+
+            this.cliCommand.launchCommand({ dryRun: true });
+
+            return this.askConfirmation();
+
+        }
 
         return (choice?.label === confirmationLabel) ? true : false;
 


### PR DESCRIPTION
When adding options, add a new choice on final confirmation to test the command with `--dryRun`.