### PR TITLE
dasherize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [4.7.0] - 2020-12-07
+
+[Angular 11.1 deprecates camelCased options in Angular CLI commands.](https://github.com/angular/angular-cli/pull/19530)
+
+So this release dasherizes them.
+
 ## [4.6.1] - 2020-11-13
 
 No change, just a released to update links in marketplace documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Better support for projects having nested Angular projects (for example because 
 
 ### Feature
 
-When adding options, add a new choice on final confirmation to test the command with `--dryRun`.
+When adding options, add a new choice on final confirmation to test the command with `--dry-run`.
 
 ## [4.2.0] - 2020-06-12
 

--- a/src/generation/cli-command.ts
+++ b/src/generation/cli-command.ts
@@ -226,7 +226,7 @@ export class CliCommand {
 
         Output.logInfo(`Launching this command: ${this.getCommand()}`);
 
-        const command = `${this.getCommand()}${dryRun ? ` --dryRun` : ''}`;
+        const command = `${this.getCommand()}${dryRun ? ` --dry-run` : ''}`;
 
         Terminal.send(this.workspaceFolder, command);
     

--- a/src/generation/cli-options.ts
+++ b/src/generation/cli-options.ts
@@ -2,13 +2,24 @@
 export type CliCommandOptions = Map<string, string | string[]>;
 
 /**
+ * Converts a camelCased string into a dasherized one (eg: `changeDetection` => `change-detection`)
+ * @param value camelCased string
+ * @returns Dasherized string
+ */
+export function dasherize(value: string): string {
+    return value.replace(/([a-z\d])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+/**
  * Format options for the generation command.
  */
 export function formatCliCommandOptions(options: CliCommandOptions | [string, string | string[]][]): string {
 
     /* Format the values. The goal is to be shortest as possible,
      * so the user can see the full command, as VS Code input box has a fixed size */
-    return Array.from(options).map(([key, value]) => {
+    return Array.from(options).map(([camelCasedKey, value]) => {
+
+        const key = dasherize(camelCasedKey);
 
         /* Boolean options are always true by default,
             * ie. `--export` is equivalent to just `--export` */
@@ -19,7 +30,7 @@ export function formatCliCommandOptions(options: CliCommandOptions | [string, st
         else if (Array.isArray(value)) {
             return value.map((valueItem) => `--${key} ${valueItem}`).join(' ');
         }
-        /* Otherwise we print the full option (eg. `--changeDetection OnPush`) */
+        /* Otherwise we print the full option (eg. `--change-detection OnPush`) */
         else {
             return `--${key} ${value}`;
         }

--- a/src/generation/index.ts
+++ b/src/generation/index.ts
@@ -1,2 +1,2 @@
 export { UserJourney } from './user-journey';
-export { CliCommandOptions, formatCliCommandOptions } from './cli-options';
+export { CliCommandOptions, formatCliCommandOptions, dasherize } from './cli-options';

--- a/src/generation/user-journey.ts
+++ b/src/generation/user-journey.ts
@@ -7,7 +7,7 @@ import { Collection, Schematic } from '../workspace/schematics';
 import { shortcutsConfirmationChoices, SHORTCUTS_CONFIRMATION_LABEL, MODULE_TYPE } from '../workspace/shortcuts';
 
 import { CliCommand } from './cli-command';
-import { CliCommandOptions, formatCliCommandOptions } from './cli-options';
+import { CliCommandOptions, dasherize, formatCliCommandOptions } from './cli-options';
 
 export class UserJourney {
 
@@ -559,7 +559,7 @@ export class UserJourney {
     private async askOptionText(optionName: string, prompt: string): Promise<string | undefined> {
 
         return vscode.window.showInputBox({
-            prompt: `--${optionName}: ${prompt}`,
+            prompt: `--${dasherize(optionName)}: ${prompt}`,
             ignoreFocusOut: true,
         });
 
@@ -568,7 +568,7 @@ export class UserJourney {
     private async askOptionEnum(optionName: string, choices: string[], placeholder: string): Promise<string | undefined> {
 
         return vscode.window.showQuickPick(choices, {
-            placeHolder: `--${optionName}: ${placeholder}`,
+            placeHolder: `--${dasherize(optionName)}: ${placeholder}`,
             ignoreFocusOut: true,
         });
 
@@ -577,7 +577,7 @@ export class UserJourney {
     private async askOptionMultiselect(optionName: string, choices: string[], placeholder: string): Promise<string[] | undefined> {
 
         return vscode.window.showQuickPick(choices, {
-            placeHolder: `--${optionName}: ${placeholder}`,
+            placeHolder: `--${dasherize(optionName)}: ${placeholder}`,
             canPickMany: true,
             ignoreFocusOut: true,
         });
@@ -594,7 +594,7 @@ export class UserJourney {
             description: `Pro-tip: take a minute to check the command above is really what you want`,
         }, {
             label: testLabel,
-            description: `Simulate the command with --dryRun`,
+            description: `Simulate the command with --dry-run`,
         }, {
             label: `$(close) Cancel`,
         }];

--- a/src/test/suite/cli-command.test.ts
+++ b/src/test/suite/cli-command.test.ts
@@ -136,7 +136,7 @@ describe('Cli command', () => {
             cliCommand.setNameAsFirstArg('hello');
             cliCommand.addOptions([['changeDetection', 'OnPush']]);
 
-            assert.strictEqual(`ng g component hello --changeDetection OnPush`, cliCommand.getCommand());
+            assert.strictEqual(`ng g component hello --change-detection OnPush`, cliCommand.getCommand());
 
         });
 
@@ -178,7 +178,7 @@ describe('Cli command', () => {
             cliCommand.setNameAsFirstArg('hello');
             cliCommand.addOptions([['export', 'true'], ['changeDetection', 'OnPush']]);
 
-            assert.strictEqual(`ng g component hello --export --changeDetection OnPush`, cliCommand.getCommand());
+            assert.strictEqual(`ng g component hello --export --change-detection OnPush`, cliCommand.getCommand());
 
         });
 
@@ -230,7 +230,7 @@ describe('Cli command', () => {
             cliCommand.setNameAsFirstArg('hello');
             cliCommand.addOptions(types.get(COMPONENT_TYPE.PAGE)!.options);
 
-            assert.strictEqual(`ng g component hello --skipSelector`, cliCommand.getCommand());
+            assert.strictEqual(`ng g component hello --skip-selector`, cliCommand.getCommand());
 
         });
 
@@ -246,7 +246,7 @@ describe('Cli command', () => {
             const typesCustomized = workspaceFolderCustomized.getComponentTypes(rootProjectName);
             cliCommand.addOptions(typesCustomized.get(COMPONENT_TYPE.PAGE)!.options);
 
-            assert.strictEqual(`ng g ${angularCollectionName}:component hello --type page --skipSelector`, cliCommand.getCommand());
+            assert.strictEqual(`ng g ${angularCollectionName}:component hello --type page --skip-selector`, cliCommand.getCommand());
             assert.strictEqual(path.join(customizedWorkspaceFolderFsPath, 'src/app/hello.page.ts'), cliCommand.guessGereratedFileFsPath());
 
         });
@@ -261,7 +261,7 @@ describe('Cli command', () => {
             cliCommand.setNameAsFirstArg('hello');
             cliCommand.addOptions(types.get(COMPONENT_TYPE.PURE)!.options);
             
-            assert.strictEqual(`ng g component hello --changeDetection OnPush`, cliCommand.getCommand());
+            assert.strictEqual(`ng g component hello --change-detection OnPush`, cliCommand.getCommand());
 
         });
 
@@ -275,7 +275,7 @@ describe('Cli command', () => {
             cliCommand.setNameAsFirstArg('hello');
             cliCommand.addOptions(types.get(COMPONENT_TYPE.EXPORTED)!.options);
             
-            assert.strictEqual(`ng g component hello --export --changeDetection OnPush`, cliCommand.getCommand());
+            assert.strictEqual(`ng g component hello --export --change-detection OnPush`, cliCommand.getCommand());
 
         });
 
@@ -292,7 +292,7 @@ describe('Cli command', () => {
             assert.strictEqual(true, typesCustomized.has(userComponentTypeLabel));
 
             cliCommand.addOptions(typesCustomized.get(userComponentTypeLabel)!.options);
-            assert.strictEqual(`ng g ${angularCollectionName}:component hello --skipSelector --entryComponent`, cliCommand.getCommand());
+            assert.strictEqual(`ng g ${angularCollectionName}:component hello --skip-selector --entry-component`, cliCommand.getCommand());
 
         });
 
@@ -309,7 +309,7 @@ describe('Cli command', () => {
             assert.strictEqual(true, typesCustomized.has(defaultComponentTypes[0]!.label));
 
             cliCommand.addOptions(typesCustomized.get(defaultComponentTypes[0]!.label)!.options);
-            assert.strictEqual(`ng g ${angularCollectionName}:component hello --type dialog --skipSelector`, cliCommand.getCommand());
+            assert.strictEqual(`ng g ${angularCollectionName}:component hello --type dialog --skip-selector`, cliCommand.getCommand());
             assert.strictEqual(path.join(customizedWorkspaceFolderFsPath, 'src/app/hello.dialog.ts'), cliCommand.guessGereratedFileFsPath());
 
         });


### PR DESCRIPTION
[Angular 11.1 deprecates camelCased options in Angular CLI commands.](https://github.com/angular/angular-cli/pull/19530)

So this release dasherizes them.